### PR TITLE
Deconfuse link Call for Linked Research

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
                     <p>Linked Research is set out to socially and technically enable researchers to take full control, ownership, and responsibility of their own knowledge, and have their contributions accessible to the society at maximum capacity, by dismantling the use of archaic and artificial barriers.</p>
 
-                    <p>This is a <a href="http://csarven.ca/call-for-linked-research">Call for Linked Research</a>!</p>
+                    <p>This is a Call for <a href="http://csarven.ca/call-for-linked-research">Linked Research</a>!</p>
 
                     <p>There is no central authority to judge the value of your contributions. You do not need permission to publish! Control your own research and communication. The Web already enables you to be the publisher!</p>
 


### PR DESCRIPTION
As the link is reference for Linked Research - not the actual call. (We want https://linkedresearch.org/ to be The Call (tm))