### PR TITLE
Remove broken links to /resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,12 +68,13 @@
               <p>Encourage others to practice Linked Research. If you run a journal, conference or workshop, accept online, Web-centric contributions; publish machine-readable proceedings; open up the review process.</p>
               <p><a href="/events/">Who is doing this?</a></p>
             </li>
+            <!-- FIXME: No longer have a list of resources?
             <li>
               <i class="fas fa-3x fa-puzzle-piece"></i>
               <h3>Resources</h3>
-              <p>Tools, techniques and resources for Linked Research are under ongoing development, and many venues are moving towards accepting work in non-traditional formats.</p>
-              <p><a href="/resources">Find out more</a></p>
+              <p>Tools, techniques and resources for Linked Research are under ongoing development, and many venues are moving towards accepting work in non-traditional formats.</p>              
             </li>
+            -->
           </ul>
 
           <section id="what-is-this" rel="schema:hasPart" resource="#what-is-this">
@@ -95,7 +96,7 @@
             <div datatype="rdf:HTML" property="schema:description">
               <p><strong>Join the chat</strong> to get involved and help to push this initiative forward. Share your ideas, efforts, struggles and solutions. What stops you from publishing Linked Research? What challenges have you encountered? What examples of Linked Research are there in your field?</p><p><i class="fa fa-comments-o"></i> <a href="http://gitter.im/linkedresearch/chat">Gitter</a> <i class="fa fa-hashtag"></i> <a href="irc://irc.freenode.net/%23linkedresearch">IRC Freenode #linkedresearch</a> <i class="fa fa-twitter"></i> <a href="https://twitter.com/Linked_Research">@Linked_Research</a> / <a href="https://twitter.com/hashtag/LinkedResearch?src=hash">#LinkedResearch</a> <i class="fa fa-github"></i> <a about="" rel="doap:repository" href="https://github.com/linkedresearch">Linked Research</a>.</p>
 
-              <p>We also list <a href="/resources">tools and techniques</a> for making your research more accessible, <a href="/events">venues and platforms</a> who are accepting and promoting work which meets our principles. If you have something to include, we'd love to hear from you: let us know in one of our chat channels, send an inbox notification to the appropriate article, or make a PR on github to add yourself.</p>
+              <p>We also list <a href="/events">venues and platforms</a> who are accepting and promoting work which meets our principles. If you have something to include, we'd love to hear from you: let us know in one of our chat channels, send an inbox notification to the appropriate article, or make a PR on github to add yourself.</p>
             </div>
           </section>
         </div>


### PR DESCRIPTION
The `/resources` page seems to have been deleted in 78545562dbca754079e731d8e59c9abd8cf96879 for unknown reasons - unless we resurrect it the links to it should be updated. Ideally we should have a `410 Gone` tombstone page if it stays away.